### PR TITLE
fix ordered missing list

### DIFF
--- a/configs/settings.yml
+++ b/configs/settings.yml
@@ -15,3 +15,4 @@ general:
   secrets_key_id: alias/secrets
 sites:
   ordered:
+    - inception


### PR DESCRIPTION
unable to do terrabutler init without a list on terrabutler settings