### PR TITLE
compatible with older direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 #shellcheck disable=SC2148,SC2155
 
-source_up_if_exists
+source_up 2>/dev/null || true
 
 # Terrabutler ENVs
 export TERRABUTLER_ENABLE=true


### PR DESCRIPTION
`source_up_if_exists` is not available on direnv `v2.25.2`, which is the latest available on ubuntu 22.04 repos.

This changes make it compatible with that version